### PR TITLE
Trigger FrameRateMonitor updates on every frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ and use it in QML (or in C++ if you prefer):
 Text { text: qsTr("fps: ") + fpsmonitor.freq }
 ```
 
+If there have been no updates to the scene, Qt will not redraw it and you will end up with a measurement of ~1fps. If you want to measure how many frames *can* be drawn per second, you can enable automatic frame update triggers via the helper
+
+```c++
+lqt::enableAutoFrameUpdates(view);
+```
+
+which causes the window to request an update on every frame swap (that is on every vsync in most cases).
+
 ### Details
 
 The frame rate is provided in a notifiable property of the ```lqt::FrameRateMonitor``` class:

--- a/lqtutils_ui.cpp
+++ b/lqtutils_ui.cpp
@@ -111,6 +111,13 @@ void FrameRateMonitor::setWindow(QQuickWindow* w)
             this, &FrameRateMonitor::registerSample);
 }
 
+QMetaObject::Connection enableAutoFrameUpdates(QQuickWindow& w)
+{
+    return QObject::connect(&w, &QQuickWindow::frameSwapped,
+                            &w, &QQuickWindow::requestUpdate);
+}
+
+
 void QmlUtils::singleShot(int msec, QJSValue callback)
 {
     QTimer::singleShot(msec, this, [callback] () mutable

--- a/lqtutils_ui.h
+++ b/lqtutils_ui.h
@@ -30,6 +30,7 @@
 #include <QList>
 #include <QJSValue>
 #include <QtGlobal>
+#include <QMetaObject>
 
 #include "lqtutils_freq.h"
 
@@ -44,6 +45,8 @@ public:
     FrameRateMonitor(QQuickWindow* w = nullptr, QObject* parent = nullptr);
     Q_INVOKABLE void setWindow(QQuickWindow* w);
 };
+
+QMetaObject::Connection enableAutoFrameUpdates(QQuickWindow& w);
 
 class ScreenLock
 {


### PR DESCRIPTION
to obtain accurate frame rate measurements even when all items are inactive.